### PR TITLE
set maximum 1000000 files on ulimit command

### DIFF
--- a/debian/kurento-media-server
+++ b/debian/kurento-media-server
@@ -17,7 +17,7 @@ unset GST_PLUGIN_PATH
 #enable core dump
 ulimit -c unlimited
 #unlimit open files
-ulimit -n $((($(cat /proc/sys/fs/file-max) * 50) / 100 ))
+ulimit -n $([ $((($(cat /proc/sys/fs/file-max) * 50) / 100 )) -le 1000000 ] && echo "$((($(cat /proc/sys/fs/file-max) * 50) / 100 ))" || echo "1000000")
 
 # Next line enables debug for some kurento classes it can be modified to change
 # log level and logged tags


### PR DESCRIPTION
On some Ubuntu 16.04 systems, the calculated max files is too large for the system. This modified command sets an upper limit to the calculation at one million files.