### PR TITLE
Bugfix: Exact username match on installation

### DIFF
--- a/debian/kurento-media-server.postinst
+++ b/debian/kurento-media-server.postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #check if the user already exists
-if [ `cat /etc/passwd | grep kurento | wc -l` -eq "0" ]; then
+if [ `cat /etc/passwd | grep -w kurento | wc -l` -eq "0" ]; then
   useradd -d /var/kurento/ kurento
 fi
 


### PR DESCRIPTION
The install script was only checking if it found anything containing the word kurento, instead of an exact match.

I had a user already added for my middleware service (which contained the word kurento), so the install script failed to create the kurento user because it thought it already existed.

Fix is to just use an exact match with grep.