### PR TITLE
If IPv6 fails to start, switch to IPv4 and try again

### DIFF
--- a/server/transport/websocket/WebSocketTransport.cpp
+++ b/server/transport/websocket/WebSocketTransport.cpp
@@ -130,17 +130,24 @@ WebSocketTransport::WebSocketTransport (const boost::property_tree::ptree
                                           this, &server, std::placeholders::_1,
                                           std::placeholders::_2) );
 
-  try {
-    if (ipv6) {
+  if (ipv6) {
+    try {
       server.listen (boost::asio::ip::tcp::v6(), port);
+    } catch (websocketpp::exception &e) {
+      GST_ERROR ("Error starting listen for websocket transport on port %d: %s using IPv6, trying IPv4", port,
+                e.what() );
+      ipv6 = false;
     }
-    else {
-      server.listen (boost::asio::ip::tcp::v4(), port);
+  }
+
+  if (!ipv6) {
+    try {
+        server.listen (boost::asio::ip::tcp::v4(), port);
+    } catch (websocketpp::exception &e) {
+      GST_ERROR ("Error starting listen for websocket transport on port %d: %s using IPv4", port,
+                e.what() );
+      exit (1);
     }
-  } catch (websocketpp::exception &e) {
-    GST_ERROR ("Error starting listen for websocket transport on port %d: %s", port,
-               e.what() );
-    exit (1);
   }
 
   websocketpp::lib::asio::error_code ep_err;


### PR DESCRIPTION
Fixes https://github.com/Kurento/bugtracker/issues/142

## What is the current behavior you want to change?

Starting on a machine without IPv6 support produces an unhelpful "Underlying Transport Error"  message.

I was trying to run in Docker for Mac. I found that it didn't work unless I set ipv6 false in the configuration JSON. 

It took a lot of searching to figure this out - the first thing I found said "We don't know why this happens in some docker installs, try upgrading docker". This was not a good introduction to the project.

## What is the new behavior provided by this change?

If `ipv6` is enabled in the config (which is the default), but is not available on the machine. It will print a modified "Underlying Transport Error" message mentioning that IPv6 is being tried, then fall back to IPv4 and try again before exiting.

## How has this been tested?

It hasn't yet. I haven't figured out how to build it. It might be horribly broken. :-)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist

- [X] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [X] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
