### PR TITLE
Introduce OpenSSL 1.1 support

### DIFF
--- a/server/transport/websocket/websocketpp/transport/asio/security/tls.hpp
+++ b/server/transport/websocket/websocketpp/transport/asio/security/tls.hpp
@@ -382,14 +382,10 @@ protected:
   template <typename ErrorCodeType>
   lib::error_code translate_ec (ErrorCodeType ec)
   {
-    if (ec.category() == lib::asio::error::get_ssl_category() ) {
-      if (ERR_GET_REASON (ec.value() ) == SSL_R_SHORT_READ) {
-        return make_error_code (transport::error::tls_short_read);
-      } else {
-        // We know it is a TLS related error, but otherwise don't know
-        // more. Pass through as TLS generic.
-        return make_error_code (transport::error::tls_error);
-      }
+
+    if (ec == boost::asio::ssl::error::stream_truncated)
+    {
+      return make_error_code (transport::error::tls_short_read);
     } else {
       // We don't know any more information about this error so pass
       // through


### PR DESCRIPTION
Based on rstudio/rstudio@e8c9a77 which is based on
chriskohlhoff/asio@92bfc62

Closes Kurento/bugtracker#467

<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

OpenSSL 1.1 is not supported


## What is the new behavior provided by this change?
<!--
Example: "Adding a function to do X",
then explain why it is necessary to have a way to do X.
-->

OpenSSL 1.1 is supported

## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, tests ran to see how
your change affects other areas of the code, etc.
-->

It builds and runs in my use case (nothing special).

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
