### PR TITLE
Pocock/json cee

### DIFF
--- a/server/logging.cpp
+++ b/server/logging.cpp
@@ -54,13 +54,26 @@ static GstDebugLevel
 g_log_level_to_gst_debug_level (GLogLevelFlags log_level)
 {
   switch (log_level & G_LOG_LEVEL_MASK) {
-  case G_LOG_LEVEL_ERROR:    return GST_LEVEL_ERROR;
-  case G_LOG_LEVEL_CRITICAL: return GST_LEVEL_ERROR;
-  case G_LOG_LEVEL_WARNING:  return GST_LEVEL_WARNING;
-  case G_LOG_LEVEL_MESSAGE:  return GST_LEVEL_FIXME;
-  case G_LOG_LEVEL_INFO:     return GST_LEVEL_INFO;
-  case G_LOG_LEVEL_DEBUG:    return GST_LEVEL_DEBUG;
-  default:                   return GST_LEVEL_DEBUG;
+  case G_LOG_LEVEL_ERROR:
+    return GST_LEVEL_ERROR;
+
+  case G_LOG_LEVEL_CRITICAL:
+    return GST_LEVEL_ERROR;
+
+  case G_LOG_LEVEL_WARNING:
+    return GST_LEVEL_WARNING;
+
+  case G_LOG_LEVEL_MESSAGE:
+    return GST_LEVEL_FIXME;
+
+  case G_LOG_LEVEL_INFO:
+    return GST_LEVEL_INFO;
+
+  case G_LOG_LEVEL_DEBUG:
+    return GST_LEVEL_DEBUG;
+
+  default:
+    return GST_LEVEL_DEBUG;
   }
 }
 
@@ -83,31 +96,32 @@ kms_glib_log_handler (const gchar   *log_domain,
 {
   const gchar *domains;
 
-  if ((log_level & DEFAULT_LEVELS) || (log_level >> G_LOG_LEVEL_USER_SHIFT)) {
+  if ( (log_level & DEFAULT_LEVELS) || (log_level >> G_LOG_LEVEL_USER_SHIFT) ) {
     goto emit;
   }
 
   domains = g_getenv ("G_MESSAGES_DEBUG");
-  if (((log_level & INFO_LEVELS) == 0) ||
-      domains == NULL ||
-      (strcmp (domains, "all") != 0 && (!log_domain || !strstr (domains, log_domain))))
-  {
+
+  if ( ( (log_level & INFO_LEVELS) == 0) ||
+       domains == NULL ||
+       (strcmp (domains, "all") != 0 && (!log_domain
+                                         || !strstr (domains, log_domain) ) ) ) {
     return;
   }
 
- emit:
-  /* we can be called externally with recursion for whatever reason */
-  if (log_level & G_LOG_FLAG_RECURSION)
-    {
-      //_g_log_fallback_handler (log_domain, log_level, message, unused_data);
-      return;
-    }
+emit:
 
-    // Forward Glib log messages through GStreamer logging
-    GstDebugCategory *category = kms_glib_debug;
-    GstDebugLevel level = g_log_level_to_gst_debug_level (log_level);
-    gst_debug_log (category, level, GST_STR_NULL (log_domain), "", 0, NULL,
-        "%s", GST_STR_NULL (message));
+  /* we can be called externally with recursion for whatever reason */
+  if (log_level & G_LOG_FLAG_RECURSION) {
+    //_g_log_fallback_handler (log_domain, log_level, message, unused_data);
+    return;
+  }
+
+  // Forward Glib log messages through GStreamer logging
+  GstDebugCategory *category = kms_glib_debug;
+  GstDebugLevel level = g_log_level_to_gst_debug_level (log_level);
+  gst_debug_log (category, level, GST_STR_NULL (log_domain), "", 0, NULL,
+                 "%s", GST_STR_NULL (message) );
 }
 
 void
@@ -133,10 +147,10 @@ debug_object (GObject *object)
   if (GST_IS_PAD (object) && GST_OBJECT_NAME (object) ) {
     boost::format fmt ("<%s:%s> ");
     fmt %
-        (GST_OBJECT_PARENT(object) != nullptr
-             ? GST_OBJECT_NAME(GST_OBJECT_PARENT(object))
-             : "''") %
-        GST_OBJECT_NAME(object);
+    (GST_OBJECT_PARENT (object) != nullptr
+     ? GST_OBJECT_NAME (GST_OBJECT_PARENT (object) )
+     : "''") %
+    GST_OBJECT_NAME (object);
     return fmt.str();
   }
 
@@ -174,14 +188,29 @@ static severity_level
 gst_debug_level_to_severity_level (GstDebugLevel level)
 {
   switch (level) {
-  case GST_LEVEL_ERROR:   return error;
-  case GST_LEVEL_WARNING: return warning;
-  case GST_LEVEL_FIXME:   return fixme;
-  case GST_LEVEL_INFO:    return info;
-  case GST_LEVEL_DEBUG:   return debug;
-  case GST_LEVEL_LOG:     return log;
-  case GST_LEVEL_TRACE:   return trace;
-  default:                return undefined;
+  case GST_LEVEL_ERROR:
+    return error;
+
+  case GST_LEVEL_WARNING:
+    return warning;
+
+  case GST_LEVEL_FIXME:
+    return fixme;
+
+  case GST_LEVEL_INFO:
+    return info;
+
+  case GST_LEVEL_DEBUG:
+    return debug;
+
+  case GST_LEVEL_LOG:
+    return log;
+
+  case GST_LEVEL_TRACE:
+    return trace;
+
+  default:
+    return undefined;
   }
 }
 
@@ -264,7 +293,7 @@ system_formatter (logging::record_view const &rec,
   date_time_formatter (rec, strm) << " ";
   strm << std::to_string (getpid() ) << " ";
   strm << logging::extract< attrs::current_thread_id::value_type > ("ThreadID",
-           rec) << " ";
+       rec) << " ";
   strm << logging::extract< severity_level > ("Severity", rec) << " ";
   strm << logging::extract< std::string > ("Category", rec) << " ";
   strm << logging::extract< std::string > ("FileName", rec) << ":";
@@ -278,7 +307,7 @@ bool
 kms_init_logging_files (const std::string &path, int fileSize, int fileNumber)
 {
   gst_debug_remove_log_function (gst_debug_log_default);
-  gst_debug_add_log_function(kms_log_function, nullptr, nullptr);
+  gst_debug_add_log_function (kms_log_function, nullptr, nullptr);
 
   boost::shared_ptr< logging::core > core = logging::core::get();
 
@@ -316,14 +345,15 @@ kms_init_logging_files (const std::string &path, int fileSize, int fileNumber)
   /* Set an exception handler to manage error cases such as missing
    * file write permissions */
   struct ex_handler {
-    void operator() (std::runtime_error const& e) const {
+    void operator() (std::runtime_error const &e) const
+    {
       gst_debug_remove_log_function (kms_log_function);
-      gst_debug_add_log_function(gst_debug_log_default, nullptr, nullptr);
-      GST_ERROR ("Boost.Log runtime error: %s", e.what());
+      gst_debug_add_log_function (gst_debug_log_default, nullptr, nullptr);
+      GST_ERROR ("Boost.Log runtime error: %s", e.what() );
     }
   };
-  core->set_exception_handler(logging::make_exception_handler<
-      std::runtime_error>(ex_handler()));
+  core->set_exception_handler (logging::make_exception_handler <
+                               std::runtime_error > (ex_handler() ) );
 
   return true;
 }

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -111,6 +111,53 @@ kms_init_dependencies (int *argc, char ***argv)
   /* Initialization routine to add commonly used */
   /* attributes to the logging system */
   logging::add_common_attributes();
+  boost::shared_ptr< logging::core > core = logging::core::get();
+  std::string pname (*argv[0]);
+  core->add_global_attribute ("ProcessName",
+                              boost::log::attributes::constant< std::string > ( pname ) );
+
+  std::string fqdn;
+  {
+    struct addrinfo hints, *info;
+    int gai_result;
+
+    char hostname[1024];
+    hostname[1023] = '\0';
+    gethostname (hostname, 1023);
+
+    memset (&hints, 0, sizeof (hints) );
+    hints.ai_family = AF_UNSPEC;    /*either IPV4 or IPV6 */
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_CANONNAME;
+
+    if ( (gai_result = getaddrinfo (hostname, 0, &hints, &info) ) != 0) {
+      fqdn = "?";
+    } else if (info == NULL) {
+      fqdn = "?";
+    } else {
+      fqdn = info->ai_canonname;
+    }
+
+    freeaddrinfo (info);
+  }
+  core->add_global_attribute ("FQDN",
+                              boost::log::attributes::constant< std::string > (fqdn) );
+
+  // when running multiple instances of the application on the same host,
+  // or running a series of tests, this can be used to distinguish each of them
+  // by setting a different value of GST_DEBUG_APPNAME for each process or each
+  // test run
+  std::string appname;
+  const char *g_app_name = getenv ("GST_DEBUG_APPNAME");
+
+  if (g_app_name == NULL) {
+    appname = pname;
+  } else {
+    appname = g_app_name;
+  }
+
+  core->add_global_attribute ("AppName",
+                              boost::log::attributes::constant< std::string > (appname) );
 }
 
 int

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -206,7 +206,7 @@ main (int argc, char **argv)
 
     if (vm.count ("version") || vm.count ("list") ) {
       // Disable log to just print version
-      gst_debug_remove_log_function_by_data(nullptr);
+      gst_debug_remove_log_function_by_data (nullptr);
     }
 
     loadModules (modulesPath);
@@ -233,9 +233,9 @@ main (int argc, char **argv)
   /* Install our signal handler */
   signalAction.sa_handler = signal_handler;
 
-  sigaction(SIGINT, &signalAction, nullptr);
-  sigaction(SIGTERM, &signalAction, nullptr);
-  sigaction(SIGPIPE, &signalAction, nullptr);
+  sigaction (SIGINT, &signalAction, nullptr);
+  sigaction (SIGTERM, &signalAction, nullptr);
+  sigaction (SIGPIPE, &signalAction, nullptr);
 
   GST_INFO ("Kurento Media Server version: %s", get_version () );
 


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
Add support for structured logging in the JSON CEE format.
This makes it much easier to load the logs into tools like OpenSearch.
This makes it much easier to combine logs from multiple application servers (media, SIP, XMPP, TURN, web servers) and merge the logs from all processes with events in time order.
I contributed similar patches for reSIProcate and GStreamer already, it is well documented in the GStreamer pull request:
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/847
https://github.com/resiprocate/resiprocate/commit/d1df9aeb956be79253560fe3628b3f37a4ef94f2


## What is the new behavior provided by this change?
When the environment variable ```GST_DEBUG_STRUCTURED=JSON_CEE``` exists, each log line will be in JSON format, following the CEE conventions, like this:

```
{
    "appname": "foo",
    "file!line": 519,
    "file!name": "gstregistrychunks.c",
    "hostname": "lab1.example.org",
    "msg": "Added pad_template sink",
    "native!function": "gst_registry_chunks_load_pad_template",
    "native!object": "",
    "native!time!elapsed": 679585795,
    "pname": "/usr/bin/kurento-media-server",
    "pri": "DEBUG",
    "proc!id": 9963,
    "proc!tid": 93905064053760,
    "subsys": "GST_REGISTRY",
    "time": "2021-07-04T12:58:21.076937000Z"
}
```

## How has this been tested?
Tested with Kurento as daemon, validated the log files with ```python -mjson.tool```
Tested with Kurento in foreground, validated the output with ```python -mjson.tool```

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [x] My change requires a change in other repository <!-- Explain which one -->

When running as a daemon, the Boost log formatting function in main/logging.cpp is used.  This doesn't depend on any change to GStreamer.

When running in the foreground, Kurento relies on the code in GStreamer to write and format the log lines.  Therefore, I backported the change from GStreamer upstream for Kurento's GStreamer fork, I'll submit that pull request too.


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
