### PR TITLE
death_handler.cpp: support OpenPOWER (ppc64)

### DIFF
--- a/server/death_handler.cpp
+++ b/server/death_handler.cpp
@@ -607,6 +607,14 @@ void DeathHandler::SignalHandler (int sig, void * /* info */, void *secret)
   trace[1] = reinterpret_cast<void *> (uc->uc_mcontext.pc);
 #elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__)
   trace[1] = reinterpret_cast<void *> (uc->uc_mcontext.regs->nip);
+#elif defined(__mips__)
+  trace[1] = reinterpret_cast<void *> (uc->uc_mcontext.pc);
+#elif defined(__s390__)
+#if defined(__s390x__)
+  trace[1] = reinterpret_cast<void *> (uc->uc_mcontext.psw.addr);
+#else
+  trace[1] = reinterpret_cast<void *> (uc->uc_mcontext.psw.addr & 0x7fffffff);
+#endif
 #else
 #if !defined(__i386__) && !defined(__x86_64__)
 #error Only ARM, x86 and x86-64 are supported

--- a/server/death_handler.cpp
+++ b/server/death_handler.cpp
@@ -605,6 +605,8 @@ void DeathHandler::SignalHandler (int sig, void * /* info */, void *secret)
   trace[1] = reinterpret_cast<void *> (uc->uc_mcontext.arm_pc);
 #elif defined(__aarch64__)     
   trace[1] = reinterpret_cast<void *> (uc->uc_mcontext.pc);
+#elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__)
+  trace[1] = reinterpret_cast<void *> (uc->uc_mcontext.regs->nip);
 #else
 #if !defined(__i386__) && !defined(__x86_64__)
 #error Only ARM, x86 and x86-64 are supported


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
Kurento doesn't compile on ppc64 CPUs (e.g. POWER9)


## What is the new behavior provided by this change?
support the POWER9 CPU registers


## How has this been tested?
[I have a POWER9 workstation for testing](https://danielpocock.com/talos-II-quickstart/)

After making the change, I made some test calls with one of my applications.

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
