### PR TITLE
WebSocketTransport: allow to set listen address in config (fixes kurento/bugtracker#518 and kurento/bugtracker#290)

### DIFF
--- a/kurento.conf.info
+++ b/kurento.conf.info
@@ -13,6 +13,7 @@ mediaServer
   {
     websocket
     {
+;     address 0.0.0.0
       port 8888
       path kurento
       threads 10

--- a/kurento.conf.ini
+++ b/kurento.conf.ini
@@ -7,6 +7,7 @@
 garbageCollectorPeriod=240
 
 [mediaServer.net.websocket]
+; address=0.0.0.0
 port=8888
 path=kurento
 threads=10

--- a/kurento.conf.json
+++ b/kurento.conf.json
@@ -16,7 +16,10 @@
     },
     "net": {
       "websocket": {
-        "//": "Try (or not) to use IPv6 for the WebSocket connection, with IPv4 fallback",
+        "//": "Address to listen on.",
+        "//": "Default: [::] (IPv6) or 0.0.0.0 (IPv4)",
+        "//address": "0.0.0.0",
+        "//": "If no address is specified, try (or not) to use IPv6 for the WebSocket connection, with IPv4 fallback",
         "//": "Default: true",
         "//ipv6": false,
         "//": "WebSocket port where API clients connect to control KMS",

--- a/server/transport/websocket/WebSocketTransport.cpp
+++ b/server/transport/websocket/WebSocketTransport.cpp
@@ -123,6 +123,8 @@ WebSocketTransport::initWebSocket (const boost::property_tree::ptree &config)
 {
   const bool ipv6 = config.get<bool> (
       "mediaServer.net.websocket.ipv6", WEBSOCKET_IPV6_DEFAULT);
+  optional<const std::string> address_str =
+            config.get_optional<std::string> ("mediaServer.net.websocket.address");
   const uint16_t port =
       config.get<uint16_t> ("mediaServer.net.websocket.port", 0);
   const uint connqueue = config.get<uint> (
@@ -152,28 +154,42 @@ WebSocketTransport::initWebSocket (const boost::property_tree::ptree &config)
               & WebSocketTransport::processMessage,
           this, &server, std::placeholders::_1, std::placeholders::_2));
 
-  // Connect to IPv6 if enabled, with fallback to IPv4 if v6 fails
-  bool try_ipv6 = ipv6;
+  if (address_str) {
+      boost::asio::ip::address address = boost::asio::ip::address::from_string(*address_str);
+      boost::asio::ip::tcp::endpoint endpoint(address, port);
+      try {
+          server.listen(endpoint);
+      } catch (websocketpp::exception &e) {
+          GST_ERROR(
+                  "WebSocket error: cannot listen on address %s and port %u (%s)",
+                  address_str, port, e.what());
+          return;
+      }
+  } else {
 
-  if (try_ipv6) {
-    try {
-      server.listen (boost::asio::ip::tcp::v6 (), port);
-    } catch (websocketpp::exception &e) {
-      GST_ERROR (
-          "WebSocket error: cannot listen on IPv6 port %u (%s), will try IPv4",
-          port, e.what ());
-      try_ipv6 = false;
-    }
-  }
+      // Connect to IPv6 if enabled, with fallback to IPv4 if v6 fails
+      bool try_ipv6 = ipv6;
 
-  if (!try_ipv6) {
-    try {
-      server.listen (boost::asio::ip::tcp::v4 (), port);
-    } catch (websocketpp::exception &e) {
-      GST_ERROR ("WebSocket error: cannot listen on IPv4 port %u (%s)", port,
-          e.what ());
-      return;
-    }
+      if (try_ipv6) {
+          try {
+              server.listen(boost::asio::ip::tcp::v6(), port);
+          } catch (websocketpp::exception &e) {
+              GST_ERROR(
+                      "WebSocket error: cannot listen on IPv6 port %u (%s), will try IPv4",
+                      port, e.what());
+              try_ipv6 = false;
+          }
+      }
+
+      if (!try_ipv6) {
+          try {
+              server.listen(boost::asio::ip::tcp::v4(), port);
+          } catch (websocketpp::exception &e) {
+              GST_ERROR("WebSocket error: cannot listen on IPv4 port %u (%s)", port,
+                        e.what());
+              return;
+          }
+      }
   }
 
   hasInsecureServer = true;


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
Resolves kurento/bugtracker#518 and kurento/bugtracker#290 to allow the server admin to specify a listen address for the websocket server. This way the port doesn't have to be exposed to the internet.


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [Contribution Guidelines](https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md)
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
