### PR TITLE
Drop dependency on forked jsoncpp library

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -87,7 +87,7 @@ Section: debug
 Depends: ${misc:Depends},
  libc6-dbgsym | libc6-dbg,
  libglib2.0-0-dbgsym | libglib2.0-0-dbg,
- kmsjsoncpp-dbg,
+ libjsoncpp1-dbgsym,
  libnice10-dbgsym,
  openwebrtc-gst-plugins-dbg,
  libgstreamer1.5-0-dbg,

--- a/server/ServerMethods.cpp
+++ b/server/ServerMethods.cpp
@@ -25,7 +25,6 @@
 #include <jsonrpc/JsonRpcException.hpp>
 #include <jsonrpc/JsonRpcUtils.hpp>
 #include <jsonrpc/JsonRpcConstants.hpp>
-#include <jsonrpc/JsonFixes.hpp>
 
 #include <sstream>
 #include <boost/uuid/uuid.hpp>
@@ -712,7 +711,7 @@ injectRefs (Json::Value &params, Json::Value &responses)
       injectRefs(param, responses);
     }
   } else if (params.isConvertibleTo (Json::ValueType::stringValue) ) {
-    std::string param = JsonFixes::getString (params);
+    std::string param = params.asString();
 
     if (param.size() > NEW_REF.size()
         && param.substr (0, NEW_REF.size() ) == NEW_REF) {


### PR DESCRIPTION
Drop dependency on forked jsoncpp library

Kurento has always used a customized fork of the [jsoncpp](https://github.com/open-source-parsers/jsoncpp) library: [kmsjsoncpp](https://github.com/Kurento/jsoncpp), which consists on the upstream version 1.6.3 plus some modifications on top of it:

* [Convert string to numbers when possible (90ea316)](https://github.com/Kurento/jsoncpp/commit/90ea316d71405ba748ededadf228eb19be215589)

    This was, in my opinion, a Bad Idea™. Automatically converting all strings to their integer representation is something that belongs to the end application, and has no place in a JSON parsing library. The authors of *jsoncpp* have indeed rejected adding this feature in several occasions, with good reasons:

    * [#270 Convert string to numbers when possible](https://github.com/open-source-parsers/jsoncpp/pull/270)
    * [#477 Add string conversion to other types](https://github.com/open-source-parsers/jsoncpp/pull/477)
    
    Kurento relies on the automatic conversion of strings to integers, so this change brings this conversion into the adequate place within the module that parses JSON values.

* [Add int64Value data (8b2dfcc)](https://github.com/Kurento/jsoncpp/commit/8b2dfccf844ced7cbd93038eafcbb4139324f282)

    Adding `int64Value` to the enum of possible types was, IMHO, a more reasonable change, because otherwise the class method `Json::Value::isConvertibleTo({Type})` is rendered unreliable and code needs to complement all calls to it with an extra call to the `is{Type}()` kind of methods. I opened a discussion around this topic, here:
    
    [Why isConvertibleTo never supported int64Value?](https://github.com/open-source-parsers/jsoncpp/discussions/1436).
    
    All of the generic code templates that Kurento Module Creator uses for code generation, used the `isConvertibleTo()` method to verify value types. Given that this method is unreliable for `int64`, all of those calls have been complemented with explicit calls to `is{Type}()`

Linked PRs:

* https://github.com/Kurento/kms-jsonrpc/pull/4
* https://github.com/Kurento/kurento-module-creator/pull/7
* https://github.com/Kurento/kurento-media-server/pull/22
