### PR TITLE
Kurento 7.0: Drop dependency on forked jsoncpp library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -DGST_DISABLE_DEPRECATED")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGST_DISABLE_DEPRECATED")
 
 include(GenericFind)
+generic_find(LIBNAME KmsJsonRpc VERSION ^7.0.0-dev REQUIRED)
 generic_find(LIBNAME KMSCORE VERSION ^7.0.0-dev REQUIRED)
 
 # Generate file "config.h"

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -40,6 +40,7 @@ set_property (TARGET kurento-media-server
     ${CMAKE_CURRENT_BINARY_DIR}/..
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/transport
+    ${KmsJsonRpc_INCLUDE_DIRS}
     ${KMSCORE_INCLUDE_DIRS}
     ${PROJECT_SOURCE_DIR}/3rdparty/DeathHandler
 )

--- a/server/ServerMethods.cpp
+++ b/server/ServerMethods.cpp
@@ -25,7 +25,6 @@
 #include <jsonrpc/JsonRpcException.hpp>
 #include <jsonrpc/JsonRpcUtils.hpp>
 #include <jsonrpc/JsonRpcConstants.hpp>
-#include <jsonrpc/JsonFixes.hpp>
 
 #include <sstream>
 #include <boost/uuid/uuid.hpp>
@@ -714,7 +713,7 @@ injectRefs (Json::Value &params, Json::Value &responses)
       injectRefs(param, responses);
     }
   } else if (params.isConvertibleTo (Json::ValueType::stringValue) ) {
-    std::string param = JsonFixes::getString (params);
+    std::string param = params.asString();
 
     if (param.size() > NEW_REF.size()
         && param.substr (0, NEW_REF.size() ) == NEW_REF) {

--- a/server/transport/CMakeLists.txt
+++ b/server/transport/CMakeLists.txt
@@ -24,6 +24,7 @@ set_property (TARGET transport
     ${CMAKE_CURRENT_SOURCE_DIR}/websocket/
     ${GSTREAMER_INCLUDE_DIRS}
     ${GLIBMM_INCLUDE_DIRS}
+    ${KmsJsonRpc_INCLUDE_DIRS}
     ${KMSCORE_INCLUDE_DIRS}
 )
 

--- a/server/transport/websocket/CMakeLists.txt
+++ b/server/transport/websocket/CMakeLists.txt
@@ -20,8 +20,8 @@ endif()
 
 target_link_libraries(websocketTransport
   ${GSTREAMER_LIBRARIES}
-  ${JSONRPC_LIBRARIES}
   ${OPENSSL_LIBRARIES}
+  ${KmsJsonRpc_LIBRARIES}
   ${KMSCORE_LIBRARIES}
 )
 
@@ -29,7 +29,7 @@ set_property (TARGET websocketTransport
   PROPERTY INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/..
-    ${JSONRPC_INCLUDE_DIRS}
+    ${KmsJsonRpc_INCLUDE_DIRS}
     ${GSTREAMER_INCLUDE_DIRS}
     ${KMSCORE_INCLUDE_DIRS}
 )


### PR DESCRIPTION
Kurento has always used a customized fork of the [jsoncpp](https://github.com/open-source-parsers/jsoncpp) library: [kmsjsoncpp](https://github.com/Kurento/jsoncpp), which consists on the upstream version 1.6.3 plus some modifications on top of it:

* [Convert string to numbers when possible (90ea316)](https://github.com/Kurento/jsoncpp/commit/90ea316d71405ba748ededadf228eb19be215589)

    This was, in my opinion, a Bad Idea™. Automatically converting all strings to their integer representation is something that belongs to the end application, and has no place in a JSON parsing library. The authors of *jsoncpp* have indeed rejected adding this feature in several occasions, with good reasons:

    * [#270 Convert string to numbers when possible](https://github.com/open-source-parsers/jsoncpp/pull/270)
    * [#477 Add string conversion to other types](https://github.com/open-source-parsers/jsoncpp/pull/477)
    
    Kurento relies on the automatic conversion of strings to integers, so this change brings this conversion into the adequate place within the module that parses JSON values.

* [Add int64Value data (8b2dfcc)](https://github.com/Kurento/jsoncpp/commit/8b2dfccf844ced7cbd93038eafcbb4139324f282)

    Adding `int64Value` to the enum of possible types was, IMHO, a more reasonable change, because otherwise the class method `Json::Value::isConvertibleTo({Type})` is rendered unreliable and code needs to complement all calls to it with an extra call to the `is{Type}()` kind of methods. I opened a discussion around this topic, here:
    
    [Why isConvertibleTo never supported int64Value?](https://github.com/open-source-parsers/jsoncpp/discussions/1436).
    
    All of the generic code templates that Kurento Module Creator uses for code generation, used the `isConvertibleTo()` method to verify value types. Given that this method is unreliable for `int64`, all of those calls have been complemented with explicit calls to `is{Type}()`

Linked PRs:

* https://github.com/Kurento/kms-jsonrpc/pull/6
* https://github.com/Kurento/kurento-module-creator/pull/9
* https://github.com/Kurento/kurento-media-server/pull/24

Closes https://github.com/Kurento/bugtracker/issues/602
